### PR TITLE
Bump asm from 9.8 to 9.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,27 +18,27 @@
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
-            <version>9.8</version>
+            <version>9.9.1</version>
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-commons</artifactId>
-            <version>9.8</version>
+            <version>9.9.1</version>
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-util</artifactId>
-            <version>9.8</version>
+            <version>9.9.1</version>
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-tree</artifactId>
-            <version>9.8</version>
+            <version>9.9.1</version>
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-analysis</artifactId>
-            <version>9.8</version>
+            <version>9.9.1</version>
         </dependency>
         <!-- json cuz idk how to do yaml shit -->
         <dependency>


### PR DESCRIPTION
Adds [support for Java 26 and some other bugfixes](https://asm.ow2.io/versions.html). Tested with the provided sample.