### PR TITLE
Negate `preserveRecordNames` check

### DIFF
--- a/src/main/java/dev/lvstrng/aidsfuscator/transform/impl/rename/FieldRenameTransformer.java
+++ b/src/main/java/dev/lvstrng/aidsfuscator/transform/impl/rename/FieldRenameTransformer.java
@@ -34,7 +34,7 @@ public class FieldRenameTransformer extends Transformer {
         }
 
         remap(context);
-        if(preserveRecordNames.value())
+        if(!preserveRecordNames.value())
             transformRecordMethods(context);
     }
 


### PR DESCRIPTION
`preserveRecordNames` suggests that we should keep the field names.

In the code, we're obfuscating/removing exposed record fields if this option is `true`, which doesn't make sense.