### PR TITLE
Fix StringIndexOutOfBoundsException in records renamer

### DIFF
--- a/src/main/java/dev/lvstrng/aidsfuscator/transform/impl/rename/FieldRenameTransformer.java
+++ b/src/main/java/dev/lvstrng/aidsfuscator/transform/impl/rename/FieldRenameTransformer.java
@@ -83,11 +83,12 @@ public class FieldRenameTransformer extends Transformer {
                 if(!(arg instanceof Handle handle))
                     continue;
 
-                newNames.append(handle.getName()).append(";");
+                newNames.append(handle.getName());
+                if (i < indy.bsmArgs.length - 1) {
+                    newNames.append(";");
+                }
             }
 
-            // delete last ; cuz idk, it will work with it anyway but still
-            newNames.deleteCharAt(newNames.length() - 1);
             indy.bsmArgs[1] = newNames.toString();
         }
     }


### PR DESCRIPTION
If no handle is found, `preserveRecordNames` throws a `StringIndexOutOfBoundsException`.