### PR TITLE
InsnBuilder `_const` method change.

### DIFF
--- a/src/main/java/dev/lvstrng/aidsfuscator/utils/InsnBuilder.java
+++ b/src/main/java/dev/lvstrng/aidsfuscator/utils/InsnBuilder.java
@@ -76,9 +76,37 @@ public class InsnBuilder {
         return this;
     }
 
-    public InsnBuilder _const(Object value) {
-        list.add(new LdcInsnNode(value));
+    private static final int STRING_CHUNK_SIZE = 16384;
+
+    /**
+     * Append string load.
+     * @author a114
+     */
+    private InsnBuilder appendStringLoad(String str) {
+        if (str.length() <= STRING_CHUNK_SIZE) {
+            list.add(new LdcInsnNode(str));
+            return this;
+        }
+        list.add(new TypeInsnNode(NEW, "java/lang/StringBuilder"));
+        list.add(new InsnNode(DUP));
+        list.add(new MethodInsnNode(INVOKESPECIAL, "java/lang/StringBuilder", "<init>", "()V"));
+
+        for (int i = 0; i < str.length(); i += STRING_CHUNK_SIZE) {
+            String chunk = str.substring(i, Math.min(i + STRING_CHUNK_SIZE, str.length()));
+            list.add(new LdcInsnNode(chunk));
+            list.add(new MethodInsnNode(INVOKEVIRTUAL, "java/lang/StringBuilder", "append", "(Ljava/lang/String;)Ljava/lang/StringBuilder;"));
+        }
+        list.add(new MethodInsnNode(INVOKEVIRTUAL, "java/lang/StringBuilder", "toString", "()Ljava/lang/String;"));
         return this;
+    }
+
+    public InsnBuilder _const(Object value) {
+        if (value instanceof String str) {
+            return appendStringLoad(str);
+        } else {
+            list.add(new LdcInsnNode(value));
+            return this;
+        }
     }
 
     public InsnBuilder method(int op, String owner, String name, String desc) {


### PR DESCRIPTION
Previously `StringEncryptTransformer` fails on classes with multiple long strings, due to their initializers calling `InsnBuilder._const(String)` directly, which creates an `LdcInsnNode` containing the a very long string literal.

[While the JVM specification allows `CONSTANT_Utf8_info` entries up to 65535 bytes](https://docs.oracle.com/javase/specs/jvms/se25/html/jvms-4.html#jvms-4.11), large encrypted string initializers can easily approach or exceed practical constant pool limits, especially when multiple long strings are emitted into the same class.
